### PR TITLE
Fix broken links in header and now properly uses site.baseurl

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ description: > # this means to ignore newlines until "baseurl:"
   Write an awesome description for your new site here. You can edit this
   line in _config.yml. It will appear in your document head meta (for
   Google search results) and in your feed.xml site description.
-baseurl: "" # the subpath of your site, e.g. /blog
+baseurl: "PACO" # the subpath of your site, e.g. /blog
 url: "www.example.com" # the base hostname & protocol for your site
 
 # Build settings

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,15 +1,15 @@
 <header class = "Site-header">
   <p class = "logocontainer">
-     <a href = "/" class = "logo">PACO</a>
+     <a href = "/{{ site.baseurl }}" class = "logo">PACO</a>
      <span class = "quote">Paderborn Approximate <br> CPU Core</span>
   </p>
   <nav class = "Site-nav">
      <ul>
-        <li class = "active"><a href = "/idea">Idea</a></li>
-        <li><a href = "/gettingstarted">Getting Started</a></li>
-        <li><a href = "/tutorial">Tutorial</a></li>
-        <li><a href = "/documentation">Documentation</a></li> 
-        <li><a href = "/publications">Publications</a></li>
+        <li class = "active"><a href = "{{ site.baseurl }}/idea">Idea</a></li>
+        <li><a href = "/{{ site.baseurl }}/gettingstarted">Getting Started</a></li>
+        <li><a href = "/{{ site.baseurl }}/tutorial">Tutorial</a></li>
+        <li><a href = "/{{ site.baseurl }}/documentation">Documentation</a></li> 
+        <li><a href = "/{{ site.baseurl }}/publications">Publications</a></li>
      </ul>
   </nav>
   <a href = "https://github.com/PACO-CPU/PACO">


### PR DESCRIPTION
Signed-off-by: Bastian Koppelmann kbastian@mail.uni-paderborn.de
